### PR TITLE
feat: HALL 헤더 고정 구현 (1.2.0)

### DIFF
--- a/src/renderer/src/pages/hall/order/HallOrderBoxComp.tsx
+++ b/src/renderer/src/pages/hall/order/HallOrderBoxComp.tsx
@@ -60,7 +60,7 @@ function HallOrderBoxComp({
           </div>
         )}
         <div className="flex w-full flex-col gap-3">
-          <div className="flex w-full items-start gap-3">
+          <div className="flex w-full items-start justify-between gap-3">
             <span
               className={cn(
                 "text-3xl leading-normal font-semibold",

--- a/src/renderer/src/pages/hall/order/HallOrderPage.tsx
+++ b/src/renderer/src/pages/hall/order/HallOrderPage.tsx
@@ -108,7 +108,7 @@ function HallOrderPage() {
           </div>
           <div
             className={cn(
-              "relative transition-opacity duration-200 ease-out",
+              "relative transition-opacity duration-600 ease-out",
               isSticky ? "opacity-100" : "opacity-0"
             )}
           >

--- a/src/renderer/src/pages/hall/order/HallOrderPage.tsx
+++ b/src/renderer/src/pages/hall/order/HallOrderPage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { LogoIcon, LogoTextIcon } from "@renderer/assets/logos";
 import Button from "@renderer/components/Button/Button";
@@ -10,10 +10,14 @@ import HallActionCompleteModalComp from "@renderer/pages/hall/order/HallActionCo
 import HallOrderComp from "@renderer/pages/hall/order/HallOrderComp";
 import HallStaffCallComp from "@renderer/pages/hall/order/HallStaffCallComp";
 import { StaffCall } from "@renderer/types/domain";
+import cn from "@renderer/utils/cn";
 import { overlay } from "overlay-kit";
 
 function HallOrderPage() {
   const navigate = useNavigate();
+  const headerRef = useRef<HTMLDivElement | null>(null);
+
+  const [isSticky, setIsSticky] = useState(false);
   const [served, setServed] = useState(false);
 
   const { waitings } = useGetHallWaitings();
@@ -37,6 +41,18 @@ function HallOrderPage() {
     ));
   };
 
+  useEffect(() => {
+    const checkSticky = () => {
+      if (headerRef.current) {
+        const bool = headerRef.current.getBoundingClientRect().top <= 0;
+        setIsSticky(bool);
+      }
+    };
+    checkSticky();
+    window.addEventListener("scroll", checkSticky, { passive: true });
+    return () => window.removeEventListener("scroll", checkSticky);
+  }, []);
+
   return (
     <div className="min-h-dvh w-full bg-gray-700">
       <header className="flex flex-row items-center justify-between bg-white px-15 pt-10 pb-8">
@@ -44,7 +60,7 @@ function HallOrderPage() {
           <LogoIcon className="h-15 w-15" />
           <LogoTextIcon className="h-[25px]" />
         </button>
-        <div className="relative">
+        <div className={cn("relative", isSticky ? "opacity-0" : "opacity-100")}>
           <Button
             color={ColorName.GREY}
             className="button-xl bg-gray-300! text-white!"
@@ -55,22 +71,62 @@ function HallOrderPage() {
           <div className="bg-primary absolute -top-5 -right-5 flex h-10 w-10 items-center justify-center rounded-full text-xl font-semibold text-white">
             {waitings.length}
           </div>
+          <div ref={headerRef} />
         </div>
       </header>
-      <div className="flex flex-col gap-4 px-15 py-8">
-        <section className="flex flex-row gap-3 rounded-2xl bg-white px-4 py-3">
-          {tabs.map((tab) => (
+
+      <div
+        className={cn(
+          "transition-[padding] duration-300 ease-out",
+          isSticky ? "sticky top-0 z-100 px-0 pt-0" : "px-15 pt-8 pb-4"
+        )}
+      >
+        <section
+          className={cn(
+            "flex justify-between bg-white transition-[padding,border-radius] duration-300 ease-out",
+            isSticky ? "rounded-none px-19 pt-7 pb-6 shadow-sm" : "rounded-2xl px-4 py-3"
+          )}
+        >
+          <div className="flex flex-row gap-3">
+            {tabs.map((tab) => (
+              <Button
+                key={tab.label}
+                color={served === tab.isServed ? ColorName.BLACK : ColorName.GREY}
+                variant={served === tab.isServed ? "default" : "outline"}
+                className="button-xl px-8! not-focus:border-gray-500!"
+                onClick={() => {
+                  if (served === tab.isServed && isSticky) {
+                    window.scrollTo({ top: 0, behavior: "smooth" });
+                    return;
+                  }
+                  setServed(tab.isServed);
+                }}
+              >
+                {tab.label} {tab.count}건
+              </Button>
+            ))}
+          </div>
+          <div
+            className={cn(
+              "relative transition-opacity duration-200 ease-out",
+              isSticky ? "opacity-100" : "opacity-0"
+            )}
+          >
             <Button
-              key={tab.label}
-              color={served === tab.isServed ? ColorName.BLACK : ColorName.GREY}
-              variant={served === tab.isServed ? "default" : "outline"}
-              className="button-xl px-8! not-focus:border-gray-500!"
-              onClick={() => setServed(tab.isServed)}
+              color={ColorName.GREY}
+              className="button-xl bg-gray-300! text-white!"
+              onClick={() => navigate("/waiting")}
             >
-              {tab.label} {tab.count}건
+              웨이팅 관리 이동
             </Button>
-          ))}
+            <div className="bg-primary absolute -top-5 -right-5 flex h-10 w-10 items-center justify-center rounded-full text-xl font-semibold text-white">
+              {waitings.length}
+            </div>
+          </div>
         </section>
+      </div>
+
+      <div className={cn("flex flex-col gap-4 px-15 pb-8", isSticky ? "pt-4" : "")}>
         {!served && staffCalls.length > 0 && (
           <section className="flex flex-col gap-6 rounded-2xl border border-gray-600 bg-white p-6">
             <div className="flex items-center gap-2">


### PR DESCRIPTION
## 📝 작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요.

- sticky header 구현 및 주문/완료 버튼 클릭 시 scroll to top
  - 웨이팅 페이지 이동 버튼 표시 (top에서 hidden 처리)
- 주문한 메뉴의 크기 조정 및 메뉴와 수량 justify-between
- **추후 주문 승인 내역 구현 시 같이 머지하겠습니다.**

## 📷 스크린샷 (선택)

> 작업한 스크린 샷을 첨부해주세요.

<img width="1512" height="945" alt="스크린샷 2026-02-12 오후 9 17 45" src="https://github.com/user-attachments/assets/7910f617-73f5-411a-a476-898c0b9abdf4" />

https://github.com/user-attachments/assets/5998fec2-c0b7-4749-866d-2e71e01ce6cd

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.


